### PR TITLE
fix: danmaku clear

### DIFF
--- a/as3-danmaku/index.ts
+++ b/as3-danmaku/index.ts
@@ -372,6 +372,10 @@ export class As3Danmaku {
             this.wrap.innerHTML = '';
         }
     }
+    /** 清空弹幕 */
+    clearList() {
+        this.dmList = [];
+    }
     /** 销毁实例 */
     destroy() {
         if (this.worker) {

--- a/bas-danmaku/js/index.ts
+++ b/bas-danmaku/js/index.ts
@@ -687,6 +687,10 @@ class BasDanmaku {
         }
     }
 
+    clearList() {
+        this.dmList = [];
+    }
+
     resize(width = this.resolutionWidth, height = this.resolutionHeight) {
         this.resolutionWidth = width;
         this.resolutionHeight = height;

--- a/bilibiliplayer/js/player/danmaku.ts
+++ b/bilibiliplayer/js/player/danmaku.ts
@@ -1431,6 +1431,8 @@ class Danmaku {
             this.danmaku.visualArray.length = 0;
             this.loadPb!.allDM = [];
             this.loadPb!.allRawDM = [];
+            this.player.basDanmaku?.clearList();
+            this.player.as3Danmaku?.clearList();
         }
         this.loadPb?.appendDm(danmaku);
         this.player.directiveManager.sender(PD.DL_DANMAKU_UPDATE, {


### PR DESCRIPTION
切换弹幕时清空BAS弹幕和代码弹幕