### PR TITLE
fix: bottom danmaku wrap

### DIFF
--- a/as3-danmaku/index.ts
+++ b/as3-danmaku/index.ts
@@ -194,7 +194,7 @@ export class As3Danmaku {
             switch (msg.action) {
                 case "play": this.player?.play(); break;
                 case "pause": this.player?.pause(); break;
-                case "seek": this.player?.seek(msg.params); break;
+                case "seek": this.player?.seek(msg.params / 1000); break;
                 case "jump":
                     window.open(`https://www.bilibili.com/video/${msg.params.vid}?p=${msg.params.page}`, msg.params.window ? '_self' : '_blank');
                     break;

--- a/danmaku/component/render/css3-render.ts
+++ b/danmaku/component/render/css3-render.ts
@@ -24,8 +24,6 @@ class CSS3Render extends Render {
     font!: string; // 字体
     text!: string;
     hided: boolean = false; // 已经隐藏（正在执行消失动画
-    /** 使用换行符排版的mode */
-    private special = 0;
 
     constructor(textData: ITextDataInterface, config: IDanmakuConfigExtInterface, precise = 0, recyclingDiv?: ICycDiv) {
         super(textData, config, precise, recyclingDiv);
@@ -59,7 +57,7 @@ class CSS3Render extends Render {
         let divAppendStatus = true; // 是否需要append状态
         let fontSize = 0;
         let text = this.text = textData.text.replace(/(\/n|\\n|\n|\r\n)/g, '\n');
-        text.includes('\n') && (this.special = textData.mode);
+        text.includes('\n') && (this.special = true);
 
         if (this.recyclingDiv) {
             div = this.recyclingDiv.div;
@@ -266,7 +264,6 @@ class CSS3Render extends Render {
     }
 
     reset(x: number, y: number) {
-        this.special === 5 && (y = 0);
         if (this.textData!.vDanmaku) {
             this.element!.style.right = y + 'px';
         } else {
@@ -275,7 +272,7 @@ class CSS3Render extends Render {
     }
     // 首帧渲染位置
     firstFrame(y: number) {
-        this.special === 5 && (y = 0);
+        this.special && (y = 0);
         this.paused = true;
         if (this.textData!.vDanmaku) {
             this.element!.style.right = y + 'px';

--- a/danmaku/component/render/render.ts
+++ b/danmaku/component/render/render.ts
@@ -46,6 +46,9 @@ export abstract class Render {
     index2hover!: number; // 节点插入到页面的顺序
     stime!: number;
 
+    /** 使用换行符排版的mode */
+    protected special = false;
+
     constructor(textData: ITextDataInterface, config: IDanmakuConfigExtInterface, precise = 0, recyclingDiv?: ICycDiv) {
         this.textData = textData;
         this.config = config;


### PR DESCRIPTION
- 修复代码弹幕`player.seek`方法：参数应该为毫秒。
- 普权弹幕使用换行符排版时，底部弹幕同顶部弹幕一样处理。