### PR TITLE
Danmaku setting

### DIFF
--- a/bilibiliplayer/css/index.less
+++ b/bilibiliplayer/css/index.less
@@ -4428,7 +4428,7 @@ input {
 .bilibili-player .bilibili-player-area .bilibili-player-video-control .bilibili-player-video-btn.bilibili-player-video-btn-danmaku .bilibili-player-danmaku-setting-lite-panel {
     position: absolute;
     cursor: default;
-    top: -188px;
+    top: -248px;
     left: -116px;
     width: 222px;
     height: 174px;
@@ -4464,7 +4464,9 @@ input {
     width: 56px
 }
 
-.bilibili-player .bilibili-player-area .bilibili-player-video-control .bilibili-player-video-btn.bilibili-player-video-btn-danmaku .bilibili-player-danmaku-setting-lite-panel .bilibili-player-danmaku-setting-lite .bilibili-player-danmaku-setting-lite-row .bilibili-player-danmaku-setting-lite-opacitybar {
+.bilibili-player .bilibili-player-area .bilibili-player-video-control .bilibili-player-video-btn.bilibili-player-video-btn-danmaku .bilibili-player-danmaku-setting-lite-panel .bilibili-player-danmaku-setting-lite .bilibili-player-danmaku-setting-lite-row .bilibili-player-danmaku-setting-lite-opacitybar,
+.bilibili-player .bilibili-player-area .bilibili-player-video-control .bilibili-player-video-btn.bilibili-player-video-btn-danmaku .bilibili-player-danmaku-setting-lite-panel .bilibili-player-danmaku-setting-lite .bilibili-player-danmaku-setting-lite-row .bilibili-player-danmaku-setting-lite-danmakunumber,
+.bilibili-player .bilibili-player-area .bilibili-player-video-control .bilibili-player-video-btn.bilibili-player-video-btn-danmaku .bilibili-player-danmaku-setting-lite-panel .bilibili-player-danmaku-setting-lite .bilibili-player-danmaku-setting-lite-row .bilibili-player-danmaku-setting-lite-danmakuarea {
     font-size: 12px;
     width: 120px;
     display: inline-block;

--- a/bilibiliplayer/js/player.ts
+++ b/bilibiliplayer/js/player.ts
@@ -876,7 +876,7 @@ class Player {
         if (danmakuConfig['fontfamily'] === 'custom') {
             danmakuConfig['fontfamily'] = danmakuConfig['fontfamilycustom'];
         }
-        danmakuConfig['preventshade'] = false;
+        // danmakuConfig['preventshade'] = false;
 
         this.multipleDanmakuDebug = {
             cid: this.config.cid,

--- a/bilibiliplayer/js/player/controller/danmaku-setting-lite.ts
+++ b/bilibiliplayer/js/player/controller/danmaku-setting-lite.ts
@@ -37,6 +37,8 @@ export class DanmakuSettingLite {
     dropFrames: any;
     dropFramesTime?: number;
     dropFramesTimer?: number;
+    danmakunumber!: Slider;
+    danmakuArea!: Slider;
     constructor(public controller: Controller) {
         this.prefix = controller.prefix;
         this.player = controller.player;
@@ -64,7 +66,60 @@ export class DanmakuSettingLite {
                 this.player.set('setting_config', 'opacity', e.value.toFixed(2));
             }
         });
-        this.opacityBar.value(this.controller.config['setting_config']['opacity'])
+        this.opacityBar.value(this.controller.config['setting_config']['opacity']);
+
+        this.danmakunumber = new Slider(this.container.find(`.${this.prefix}-danmaku-setting-lite-danmakunumber`), {
+            name: "ctlbar_danmuku_number",
+            precision: 104,
+            hint: true,
+            width: 120,
+            height: 13,
+
+            valueSetAnalyze: b => (Number(b) === 0 || Number(b) === -1) ? 1 : b <= 100 ? (b - 1) / 104 : (b / 100 - 1 + 100 - 1) / 104,
+            valueGetAnalyze: b => { b = b * 104 + 1; return b <= 100 ? b : b <= 104 ? (b - 100 + 1) * 100 : 0; },
+            formatTooltip: b => { b = Math.round(b * 104 + 1); return b <= 100 ? b : b <= 104 ? (b - 100 + 1) * 100 : "无限制"; },
+            change: (e: IEvent) => {
+                player.set('setting_config', 'danmakunumber', e.value === 0 ? -1 : e.value);
+            }
+        });
+        this.danmakunumber.value(this.controller.config['setting_config']['danmakunumber']);
+
+        this.danmakuArea = new Slider(this.container.find(`.${this.prefix}-danmaku-setting-lite-danmakuarea`), {
+            name: "ctlbar_danmuku_area",
+            precision: 10,
+            hint: true,
+            width: 120,
+            height: 13,
+
+            valueSetAnalyze: b => {
+                b = b / 100;
+                b = Math.max(b, 0);
+                b = Math.min(b, 1);
+                return b;
+            },
+            valueGetAnalyze: b => {
+                b = b * 100;
+                b = Math.max(b, 0);
+                b = Math.min(b, 100);
+                return b;
+            },
+            formatTooltip: b => {
+                switch (b) {
+                    case 0:
+                        return "无限";
+                    case 0.5:
+                        return "半屏";
+                    case 1:
+                        return "满屏";
+                    default:
+                        return `${b * 100}%`;
+                }
+            },
+            change: (e: IEvent) => {
+                player.set('setting_config', 'danmakuArea', e.value);
+            }
+        });
+        this.danmakuArea.value(this.controller.config['setting_config']['danmakuArea']);
 
         this.preventshade = new Checkbox(this.container.find(`.${this.prefix}-setting-preventshade`), {
             label: "防挡字幕",
@@ -99,7 +154,7 @@ export class DanmakuSettingLite {
             }
         });
 
-        /** 暂存以相应来自别处的屏蔽消息 */
+        /** 暂存以响应来自别处的屏蔽消息 */
         const blockElem: Record<string, any> = {};
         this.type.forEach((d, i) => {
             const domName = <keyof BILIBILI_PLAYER_SETTINGS['block']>`type_${d[0].toLowerCase()}`;
@@ -277,6 +332,14 @@ export class DanmakuSettingLite {
 		                    <div class="${this.prefix}-danmaku-setting-lite-row">
 	                    		<div class="${this.prefix}-danmaku-setting-lite-title">不透明度</div>
 	                    		<div class="${this.prefix}-danmaku-setting-lite-opacitybar"></div>
+	                    	</div>
+                            <div class="${this.prefix}-danmaku-setting-lite-row">
+	                    		<div class="${this.prefix}-danmaku-setting-lite-title">弹幕密度</div>
+	                    		<div class="${this.prefix}-danmaku-setting-lite-danmakunumber"></div>
+	                    	</div>
+                            <div class="${this.prefix}-danmaku-setting-lite-row">
+	                    		<div class="${this.prefix}-danmaku-setting-lite-title">显示区域</div>
+	                    		<div class="${this.prefix}-danmaku-setting-lite-danmakuarea"></div>
 	                    	</div>
 	                    	<div class="${this.prefix}-danmaku-setting-lite-discipline"></div>
 	                    	<div class="${this.prefix}-danmaku-setting-lite-row">

--- a/bilibiliplayer/js/player/controller/setting.ts
+++ b/bilibiliplayer/js/player/controller/setting.ts
@@ -433,7 +433,11 @@ class Setting {
             formatTooltip: b => { b = Math.round(b * 104 + 1); return b <= 100 ? b : b <= 104 ? (b - 100 + 1) * 100 : "无限制"; },
             change: (e: IEvent) => {
                 player.set('setting_config', 'danmakunumber', e.value === 0 ? -1 : e.value);
+                player.controller.danmakuLite.danmakunumber.value(e.value, false);
             }
+        });
+        player.controller.danmakuLite.danmakunumber.on("change", (e: IEvent) => {
+            this.settingItem.danmakunumber!.value(e.value, false);
         });
         this.settingItem.reset = new Button(setting.find(`${prefix}reset`), {
             type: "small",
@@ -509,7 +513,7 @@ class Setting {
                 }
             });
         });
-        this.settingItem.danmakuArea = new Slider(setting.find(`${prefix}danmakuArea`), {
+        this.settingItem.danmakuArea = new Slider(setting.find(`${prefix}danmakuarea`), {
             precision: 10,
             hint: true,
             width: 175,
@@ -541,7 +545,11 @@ class Setting {
             },
             change: (e: IEvent) => {
                 player.set('setting_config', 'danmakuArea', e.value);
+                player.controller.danmakuLite.danmakuArea.value(e.value, false);
             }
+        });
+        player.controller.danmakuLite.danmakuArea.on("change", (e: IEvent) => {
+            this.settingItem.danmakuArea!.value(e.value, false);
         });
 
         // 全景模式
@@ -619,9 +627,9 @@ class Setting {
 			</div>
 		</div>
         <div class="${this.prefix}-panel-content">
-			<div class="${this.prefix}-panel-label">弹幕显示区域</div>
+			<div class="${this.prefix}-panel-label" data-tooltip="1" data-text="无限时滚动弹幕可以重合叠加" data-position="bottom-left" data-change-mode="1">弹幕显示区域</div>
 			<div class="${this.prefix}-panel-setting">
-				<div class="${this.prefix}-setting-danmakuArea"></div>
+				<div class="${this.prefix}-setting-danmakuarea"></div>
 			</div>
 		</div>
 		<div class="${this.prefix}-panel-content">

--- a/bilibiliplayer/js/player/controller/setting.ts
+++ b/bilibiliplayer/js/player/controller/setting.ts
@@ -152,7 +152,6 @@ class Setting {
             });;
         });
         this.set($.extend({}, this.config['setting_config'], this.config['video_status'], this.config['block']));
-        this.settingItem['preventshade'].value(this.player.get('setting_config', 'preventshade'));
     }
     private init() {
         if (this.initalized) {

--- a/bilibiliplayer/js/player/proto/load-pb.ts
+++ b/bilibiliplayer/js/player/proto/load-pb.ts
@@ -300,9 +300,10 @@ export default class LoadPb {
         }
         // 此处弹幕数是错误的
         // this.player.trigger(STATE.EVENT.PLAYER_SEND, { dmAllNum: data.count || 0 });
-        // 更新弹幕设置信息
-        const login = this.player.user.status().login;
-        this.setLocal(data.dmSetting, login!);
+        // ~~更新弹幕设置信息~~
+        // 使用本地保存的设置
+        // const login = this.player.user.status().login;
+        // this.setLocal(data.dmSetting, login!);
 
         this.appendDmImg(data.commandDms);
         // 弹幕关闭 不去加载弹幕


### PR DESCRIPTION
- 不再同步弹幕设置，完全使用本地设置，以解决部分设置项被覆盖的问题。
- 弹幕设置面板新增“弹幕密度”和“弹幕区域”滑动条二项，便于及时调节弹幕显示。